### PR TITLE
refactor/docker

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,0 +1,43 @@
+name: Publish Docker Container
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: NeonGeckoCom/coqui-tts
+
+jobs:
+  build_and_publish_docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build Distribution Packages
         run: |
-          python setup.py bdist_wheel
+          python setup.py sdist bdist_wheel
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -32,7 +32,7 @@ jobs:
           commit_message: Increment Version
       - name: Build Distribution Packages
         run: |
-          python setup.py bdist_wheel
+          python setup.py sdist bdist_wheel
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
           python -m pip install build wheel
       - name: Build Distribution Packages
         run: |
-          python setup.py bdist_wheel
+          python setup.py sdist bdist_wheel
   unit_tests:
     strategy:
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-buster
+
+RUN apt-get update -y && apt-get install -y libsndfile1 espeak espeak-ng python3-pip
+RUN pip3 install TTS==0.6.2
+
+COPY . /tmp/neon-tts-plugin-coqui-ai
+
+RUN pip3 install ovos-tts-server==0.0.2
+RUN pip3 install /tmp/neon-tts-plugin-coqui-ai
+
+ENTRYPOINT ovos-tts-server --engine neon-tts-plugin-coqui

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ TTS Plugin for Coqui AI Text-to-Speech.
 # Configuration:
 ```yaml
 tts:
-    module: coqui
-    coqui: {
+    module: neon-tts-plugin-coqui
+    neon-tts-plugin-coqui: {
         cache: true
     }
 ```
@@ -14,3 +14,16 @@ tts:
 `sudo apt install libsndfile1 espeak espeak-ng`
 
 Necessary for recording audio files
+
+## Docker
+
+A docker container using [ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server) is available
+
+You can build and run it locally
+
+```bash
+docker build . -t coquitts
+docker run -p 8080:9666 coquitts
+```
+
+use it `http://localhost:8080/synthesize/hello`

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,5 @@
 # dependencies
 TTS == 0.6.2
-# neon
-neon-utils~=0.16
 ovos-plugin-manager~=0.0.2
 # huggingface
 huggingface-hub

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def get_requirements(requirements_filename: str):
     return requirements
 
 
-PLUGIN_ENTRY_POINT = 'coqui = neon_tts_plugin_coqui_ai:CoquiTTS'
+PLUGIN_ENTRY_POINT = 'neon-tts-plugin-coqui = neon_tts_plugin_coqui_ai:CoquiTTS'
 
 with open("README.md", "r") as f:
     long_description = f.read()


### PR DESCRIPTION
- add Dockerfile for ovos-tts-server
- rename plugin module name to follow standards and avoid plugin load errors (coqui namespace conflict)
- refactor to not need neon_utils
   - stopwatch now available in ovos_utils 
   - speak tags now part of OPM
   - config reading belongs in the TTSFactory, this arg is meant for non mycroft/ovos/neon usage
- github action to publish container (manual trigger)


test with `docker pull ghcr.io/openvoiceos/coqui-tts:refactor-docker`


```
(.venv) [user@user-predatorph31551 neon-tts-plugin-coqui-ai]$ docker run -p 8080:9666 coquitts:latest
2022-05-02 16:59:24.571 - OVOS - ovos_plugin_manager.g2p:create:58 - DEBUG - Loaded plugin dummy
2022-05-02 16:59:24.572 - OVOS - neon_tts_plugin_coqui_ai:_init_model:192 - INFO - Initializing model for: en
 > Downloading model to /root/.local/share/tts/tts_models--en--ljspeech--vits
 > Model's license - apache 2.0
 > Check https://choosealicense.com/licenses/apache-2.0/ for more info.
 > Using model: vits
 > Setting up Audio Processor...
 | > sample_rate:22050
 | > resample:False
 | > num_mels:80
 | > log_func:np.log10
 | > min_level_db:-100
 | > frame_shift_ms:None
 | > frame_length_ms:None
 | > ref_level_db:20
 | > fft_size:1024
 | > power:1.5
 | > preemphasis:0.0
 | > griffin_lim_iters:60
 | > signal_norm:True
 | > symmetric_norm:True
 | > mel_fmin:0
 | > mel_fmax:None
 | > pitch_fmin:0.0
 | > pitch_fmax:640.0
 | > spec_gain:20.0
 | > stft_pad_mode:reflect
 | > max_norm:4.0
 | > clip_norm:True
 | > do_trim_silence:True
 | > trim_db:45
 | > do_sound_norm:False
 | > do_amp_to_db_linear:True
 | > do_amp_to_db_mel:True
 | > do_rms_norm:False
 | > db_level:None
 | > stats_path:None
 | > base:10
 | > hop_length:256
 | > win_length:1024
 > Using Griffin-Lim as no vocoder model defined
2022-05-02 16:59:40.863 - OVOS - neon_tts_plugin_coqui_ai:_init_model:199 - DEBUG - RAM=782.41015625 MiB
 * Serving Flask app 'ovos_tts_server' (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
INFO:werkzeug: * Running on all addresses (0.0.0.0)
   WARNING: This is a development server. Do not use it in a production deployment.
 * Running on http://127.0.0.1:9666
 * Running on http://172.17.0.2:9666 (Press CTRL+C to quit)
2022-05-02 16:59:53.274 - OVOS - ovos_plugin_manager.templates.tts:add_metric:404 - DEBUG - time delta: 0 metric: {'metric_type': 'tts.synth.start'}
2022-05-02 16:59:53.276 - OVOS - neon_tts_plugin_coqui_ai:_init_model:197 - DEBUG - Using loaded model for: en
2022-05-02 16:59:53.278 - OVOS - neon_tts_plugin_coqui_ai:_init_model:199 - DEBUG - RAM=782.43359375 MiB
 > Text splitted to sentences.
['hello']
 > Processing time: 0.8105275630950928
 > Real-time factor: 0.8719814971822207
2022-05-02 16:59:54.247 - OVOS - neon_tts_plugin_coqui_ai:get_audio:124 - DEBUG - TTS Synthesis time=0.966888427734375
2022-05-02 16:59:54.249 - OVOS - neon_tts_plugin_coqui_ai:get_audio:125 - DEBUG - RAM=700.2109375 MiB
2022-05-02 16:59:54.258 - OVOS - neon_tts_plugin_coqui_ai:_audio_to_file:146 - DEBUG - File access time=0.007170200347900391
2022-05-02 16:59:54.259 - OVOS - ovos_plugin_manager.templates.tts:add_metric:404 - DEBUG - time delta: 0 metric: {'metric_type': 'tts.synth.finished'}
2022-05-02 16:59:54.261 - OVOS - ovos_plugin_manager.templates.tts:add_metric:404 - DEBUG - time delta: 0 metric: {'metric_type': 'tts.phonemes.g2p.error', 'error': 'get_arpa() takes 3 positional arguments but 4 were given'}
2022-05-02 16:59:54.263 - OVOS - ovos_plugin_manager.templates.tts:add_metric:404 - DEBUG - time delta: 0 metric: {'metric_type': 'tts.synth.cached'}
INFO:werkzeug:172.17.0.1 - - [02/May/2022 16:59:54] "GET /synthesize/hello HTTP/1.1" 200 -
```